### PR TITLE
Add EmailServiceClient for Cloudflare Email Service (send API)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,9 @@ jobs:
     - run: swift build --build-tests
     - run: swift test --skip-build --enable-swift-testing --parallel
       env:
-        IMAGES_API_TOKEN: ${{ secrets.IMAGES_API_TOKEN }}
         ACCOUNT_ID: ${{ secrets.ACCOUNT_ID }}
+        IMAGES_API_TOKEN: ${{ secrets.IMAGES_API_TOKEN }}
+        EMAIL_SERVICE_API_TOKEN: ${{ secrets.EMAIL_SERVICE_API_TOKEN }}
   lint:
     runs-on: ubuntu-24.04-arm
     container: swift:latest

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,11 @@ let package = Package(
     .library(
       name: "ImagesClient",
       targets: ["ImagesClient"]
-    )
+    ),
+    .library(
+      name: "EmailServiceClient",
+      targets: ["EmailServiceClient"]
+    ),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-http-types", from: "1.3.0"),
@@ -30,6 +34,19 @@ let package = Package(
         .product(name: "HTTPTypesFoundation", package: "swift-http-types"),
         .product(name: "MultipartKit", package: "multipart-kit"),
         .product(name: "HTTPClient", package: "http-client"),
+      ]
+    ),
+    .target(
+      name: "EmailServiceClient",
+      dependencies: [
+        .product(name: "HTTPTypes", package: "swift-http-types"),
+        .product(name: "HTTPClient", package: "http-client"),
+      ]
+    ),
+    .testTarget(
+      name: "EmailServiceClientTests",
+      dependencies: [
+        .target(name: "EmailServiceClient")
       ]
     ),
     .testTarget(

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ https://developers.cloudflare.com/api
 ## API List
 
 - [x] Cloudflare Images
+- [x] Cloudflare Email Service
 
 ### Cloudflare Images
 
@@ -21,4 +22,29 @@ let uploadedImage = try await client.upload(
 )
 
 print(uploadedImage)
+```
+
+
+### Cloudflare Email Service
+
+```swift
+import EmailServiceClient
+
+let client = EmailServiceClient(
+  apiToken: "1234567890",
+  accountId: "1234567890",
+  httpClient: .urlSession(.shared)
+)
+
+let result = try await client.send(
+  EmailMessage(
+    to: "recipient@example.com",
+    from: "welcome@example.com",
+    subject: "Welcome!",
+    html: "<h1>Hello!</h1>",
+    text: "Hello!"
+  )
+)
+
+print(result.delivered)
 ```

--- a/Sources/EmailServiceClient/EmailMessage.swift
+++ b/Sources/EmailServiceClient/EmailMessage.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+public struct EmailMessage: Sendable, Codable, Hashable {
+  public var to: RecipientList
+  public var cc: [String]?
+  public var bcc: [String]?
+  public var from: Sender
+  public var replyTo: String?
+  public var subject: String
+  public var html: String?
+  public var text: String?
+  public var attachments: [Attachment]?
+  public var headers: [String: String]?
+
+  public init(
+    to: RecipientList,
+    cc: [String]? = nil,
+    bcc: [String]? = nil,
+    from: Sender,
+    replyTo: String? = nil,
+    subject: String,
+    html: String? = nil,
+    text: String? = nil,
+    attachments: [Attachment]? = nil,
+    headers: [String: String]? = nil
+  ) {
+    self.to = to
+    self.cc = cc
+    self.bcc = bcc
+    self.from = from
+    self.replyTo = replyTo
+    self.subject = subject
+    self.html = html
+    self.text = text
+    self.attachments = attachments
+    self.headers = headers
+  }
+
+  public init(
+    to: String,
+    from: String,
+    subject: String,
+    html: String? = nil,
+    text: String? = nil
+  ) {
+    self.init(
+      to: .single(to),
+      from: .address(from),
+      subject: subject,
+      html: html,
+      text: text
+    )
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case to
+    case cc
+    case bcc
+    case from
+    case replyTo = "reply_to"
+    case subject
+    case html
+    case text
+    case attachments
+    case headers
+  }
+}
+
+public enum RecipientList: Sendable, Codable, Hashable {
+  case single(String)
+  case many([String])
+
+  public init(_ recipients: [String]) {
+    if recipients.count == 1, let recipient = recipients.first {
+      self = .single(recipient)
+    } else {
+      self = .many(recipients)
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .single(let recipient):
+      try container.encode(recipient)
+    case .many(let recipients):
+      try container.encode(recipients)
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if let recipient = try? container.decode(String.self) {
+      self = .single(recipient)
+    } else {
+      self = .many(try container.decode([String].self))
+    }
+  }
+}
+
+public enum Sender: Sendable, Codable, Hashable {
+  case address(String)
+  case named(address: String, name: String)
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .address(let address):
+      try container.encode(address)
+    case .named(let address, let name):
+      try container.encode(NamedSender(address: address, name: name))
+    }
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if let address = try? container.decode(String.self) {
+      self = .address(address)
+    } else {
+      let namedSender = try container.decode(NamedSender.self)
+      self = .named(address: namedSender.address, name: namedSender.name)
+    }
+  }
+
+  private struct NamedSender: Sendable, Codable, Hashable {
+    var address: String
+    var name: String
+  }
+}
+
+public struct Attachment: Sendable, Codable, Hashable {
+  public var content: String
+  public var filename: String
+  public var type: String
+  public var disposition: String?
+
+  public init(
+    content: String,
+    filename: String,
+    type: String,
+    disposition: String? = nil
+  ) {
+    self.content = content
+    self.filename = filename
+    self.type = type
+    self.disposition = disposition
+  }
+}

--- a/Sources/EmailServiceClient/EmailResponse.swift
+++ b/Sources/EmailServiceClient/EmailResponse.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public struct EmailResponse: Sendable, Codable, Hashable {
+  public var result: Result?
+  public var success: Bool
+  public var errors: [MessageContent]
+  public var messages: [MessageContent]
+
+  public struct Result: Sendable, Codable, Hashable {
+    public var delivered: [String]
+    public var permanentBounces: [String]
+    public var queued: [String]
+
+    private enum CodingKeys: String, CodingKey {
+      case delivered
+      case permanentBounces = "permanent_bounces"
+      case queued
+    }
+  }
+}

--- a/Sources/EmailServiceClient/EmailServiceClient.swift
+++ b/Sources/EmailServiceClient/EmailServiceClient.swift
@@ -1,0 +1,27 @@
+import Foundation
+import HTTPClient
+import HTTPTypes
+
+public struct EmailServiceClient<HTTPClient: HTTPClientProtocol & Sendable>: Sendable {
+  public let apiToken: String
+  public let accountId: String
+  public let httpClient: HTTPClient
+  public var baseURL = URL(string: "https://api.cloudflare.com/client/v4")!
+
+  public init(
+    apiToken: String,
+    accountId: String,
+    httpClient: HTTPClient
+  ) {
+    self.apiToken = apiToken
+    self.accountId = accountId
+    self.httpClient = httpClient
+  }
+
+  func execute(_ request: HTTPRequest, body: Data? = nil) async throws -> (Data, HTTPResponse) {
+    var request = request
+    request.headerFields[.authorization] = "Bearer \(apiToken)"
+    request.headerFields[.contentType] = "application/json"
+    return try await httpClient.execute(for: request, from: body)
+  }
+}

--- a/Sources/EmailServiceClient/ErrorHandle.swift
+++ b/Sources/EmailServiceClient/ErrorHandle.swift
@@ -1,0 +1,23 @@
+extension EmailServiceClient {
+  static func handleError(errors: [MessageContent]) -> RequestError {
+    if errors.map(\.code).contains(10000) {
+      return .invalidAuthentication
+    } else if errors.map(\.code).contains(10001) {
+      return .invalidRequestSchema
+    } else if errors.map(\.code).contains(10200) {
+      return .invalidEmail
+    } else if errors.map(\.code).contains(10201) {
+      return .missingContentLength
+    } else if errors.map(\.code).contains(10202) {
+      return .tooBig
+    } else if errors.map(\.code).contains(10203) {
+      return .sendingDisabled
+    } else if errors.map(\.code).contains(10004) {
+      return .throttled
+    } else if errors.map(\.code).contains(10002) {
+      return .internalServer
+    } else {
+      return .unknown(errors: errors)
+    }
+  }
+}

--- a/Sources/EmailServiceClient/MessageContent.swift
+++ b/Sources/EmailServiceClient/MessageContent.swift
@@ -1,0 +1,4 @@
+public struct MessageContent: Error, Sendable, Codable, Hashable {
+  public var code: Int
+  public var message: String
+}

--- a/Sources/EmailServiceClient/RequestError.swift
+++ b/Sources/EmailServiceClient/RequestError.swift
@@ -1,0 +1,11 @@
+public enum RequestError: Error {
+  case invalidAuthentication
+  case invalidRequestSchema
+  case invalidEmail
+  case missingContentLength
+  case tooBig
+  case sendingDisabled
+  case throttled
+  case internalServer
+  case unknown(errors: [MessageContent])
+}

--- a/Sources/EmailServiceClient/SendEmail.swift
+++ b/Sources/EmailServiceClient/SendEmail.swift
@@ -1,0 +1,31 @@
+import Foundation
+import HTTPTypes
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+extension EmailServiceClient {
+  /// Send email via Cloudflare Email Service REST API.
+  /// https://developers.cloudflare.com/email-service/api/send-emails/rest-api/
+  /// - Parameter email: Email payload.
+  /// - Returns: Delivery status for recipients.
+  public func send(_ email: EmailMessage) async throws -> EmailResponse.Result {
+    let url = baseURL.appendingPathComponent("accounts/\(accountId)/email/sending/send")
+
+    let request = HTTPRequest(
+      method: .post,
+      url: url
+    )
+
+    let body = try JSONEncoder().encode(email)
+    let (data, _) = try await execute(request, body: body)
+    let response = try JSONDecoder().decode(EmailResponse.self, from: data)
+
+    if let result = response.result, response.success {
+      return result
+    } else {
+      throw Self.handleError(errors: response.errors)
+    }
+  }
+}

--- a/Tests/EmailServiceClientTests/EmailServiceClientTests.swift
+++ b/Tests/EmailServiceClientTests/EmailServiceClientTests.swift
@@ -1,0 +1,55 @@
+import EmailServiceClient
+import Foundation
+import HTTPTypesFoundation
+import Testing
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+@Suite
+struct EmailServiceClientTests {
+  let client = EmailServiceClient(
+    apiToken: ProcessInfo.processInfo.environment["EMAIL_SERVICE_API_TOKEN"]!,
+    accountId: ProcessInfo.processInfo.environment["ACCOUNT_ID"]!,
+    httpClient: .urlSession(.shared)
+  )
+
+  @Test
+  func sendEmail() async throws {
+    let result = try await client.send(
+      EmailMessage(
+        to: "zunda.dev@gmail.com",
+        from: "zunda.dev@blindlog.me",
+        subject: "Cloudflare Swift EmailServiceClient Test",
+        text: "This is a test email from EmailServiceClient."
+      )
+    )
+
+    #expect(result.delivered.isEmpty)
+    #expect(result.queued.isEmpty)
+  }
+
+  @Test
+  func decodeSendEmailResult() throws {
+    let payload = """
+      {
+        "result": {
+          "delivered": ["delivered@example.com"],
+          "permanent_bounces": ["bounced@example.com"],
+          "queued": ["queued@example.com"]
+        },
+        "success": true,
+        "errors": [],
+        "messages": []
+      }
+      """.data(using: .utf8)!
+
+    let response = try JSONDecoder().decode(EmailResponse.self, from: payload)
+
+    #expect(response.success == true)
+    #expect(response.result?.delivered == ["delivered@example.com"])
+    #expect(response.result?.permanentBounces == ["bounced@example.com"])
+    #expect(response.result?.queued == ["queued@example.com"])
+  }
+}


### PR DESCRIPTION
### Motivation

- Implement Cloudflare Email Service support (issue #45) by providing a client for the REST send API so callers can send emails via Cloudflare from Swift. 