### PR TITLE
Add MemberwiseInit for simple initializers

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d8dc06125bd11803e2c9479f6b9f3878541ead10a50a2d1085d752506fcbcf00",
+  "originHash" : "f2942f5a0e996673ea5cf8c32b312908e53e86127d04f33cbce41c24e0be682a",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -137,6 +137,15 @@
       }
     },
     {
+      "identity" : "swift-memberwise-init-macro",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gohanlon/swift-memberwise-init-macro",
+      "state" : {
+        "revision" : "d0fb82bb6638051524214fb54524bfcd876735a1",
+        "version" : "0.6.0"
+      }
+    },
+    {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
@@ -206,6 +215,15 @@
       "state" : {
         "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
         "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
+        "version" : "603.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-http-types", from: "1.3.0"),
+    .package(url: "https://github.com/gohanlon/swift-memberwise-init-macro", from: "0.6.0"),
     .package(url: "https://github.com/vapor/multipart-kit", from: "5.0.0-alpha.5"),
     .package(url: "https://github.com/zunda-pixel/http-client", from: "0.3.0"),
   ],
@@ -34,6 +35,7 @@ let package = Package(
         .product(name: "HTTPTypesFoundation", package: "swift-http-types"),
         .product(name: "MultipartKit", package: "multipart-kit"),
         .product(name: "HTTPClient", package: "http-client"),
+        .product(name: "MemberwiseInit", package: "swift-memberwise-init-macro"),
       ]
     ),
     .testTarget(
@@ -50,6 +52,7 @@ let package = Package(
       dependencies: [
         .product(name: "HTTPTypes", package: "swift-http-types"),
         .product(name: "HTTPClient", package: "http-client"),
+        .product(name: "MemberwiseInit", package: "swift-memberwise-init-macro"),
       ]
     ),
     .testTarget(

--- a/Sources/EmailService/Client.swift
+++ b/Sources/EmailService/Client.swift
@@ -1,22 +1,14 @@
 import Foundation
 import HTTPClient
 import HTTPTypes
+import MemberwiseInit
 
+@MemberwiseInit(.public)
 public struct Client<HTTPClient: HTTPClientProtocol & Sendable>: Sendable {
   public var accountId: String
   public var apiToken: String
   public var httpClient: HTTPClient
-  public var baseURL = URL(string: "https://api.cloudflare.com/client/v4")!
-
-  public init(
-    accountId: String,
-    apiToken: String,
-    httpClient: HTTPClient
-  ) {
-    self.apiToken = apiToken
-    self.accountId = accountId
-    self.httpClient = httpClient
-  }
+  public var baseURL: URL = URL(string: "https://api.cloudflare.com/client/v4")!
 
   func execute(_ request: HTTPRequest, body: Data? = nil) async throws -> (Data, HTTPResponse) {
     var request = request

--- a/Sources/EmailService/EmailMessage.swift
+++ b/Sources/EmailService/EmailMessage.swift
@@ -1,40 +1,18 @@
 import Foundation
+import MemberwiseInit
 
+@MemberwiseInit(.public)
 public struct EmailMessage: Sendable, Codable, Hashable {
   public var to: RecipientList
-  public var cc: [String]?
-  public var bcc: [String]?
+  public var cc: [String]? = nil
+  public var bcc: [String]? = nil
   public var from: Sender
-  public var replyTo: String?
+  public var replyTo: String? = nil
   public var subject: String
-  public var html: String?
-  public var text: String?
-  public var attachments: [Attachment]?
-  public var headers: [String: String]?
-
-  public init(
-    to: RecipientList,
-    cc: [String]? = nil,
-    bcc: [String]? = nil,
-    from: Sender,
-    replyTo: String? = nil,
-    subject: String,
-    html: String? = nil,
-    text: String? = nil,
-    attachments: [Attachment]? = nil,
-    headers: [String: String]? = nil
-  ) {
-    self.to = to
-    self.cc = cc
-    self.bcc = bcc
-    self.from = from
-    self.replyTo = replyTo
-    self.subject = subject
-    self.html = html
-    self.text = text
-    self.attachments = attachments
-    self.headers = headers
-  }
+  public var html: String? = nil
+  public var text: String? = nil
+  public var attachments: [Attachment]? = nil
+  public var headers: [String: String]? = nil
 
   public init(
     to: String,
@@ -128,21 +106,10 @@ public enum Sender: Sendable, Codable, Hashable {
   }
 }
 
+@MemberwiseInit(.public)
 public struct Attachment: Sendable, Codable, Hashable {
   public var content: String
   public var filename: String
   public var type: String
-  public var disposition: String?
-
-  public init(
-    content: String,
-    filename: String,
-    type: String,
-    disposition: String? = nil
-  ) {
-    self.content = content
-    self.filename = filename
-    self.type = type
-    self.disposition = disposition
-  }
+  public var disposition: String? = nil
 }

--- a/Sources/EmailService/EmailResponse.swift
+++ b/Sources/EmailService/EmailResponse.swift
@@ -1,11 +1,14 @@
 import Foundation
+import MemberwiseInit
 
+@MemberwiseInit(.public)
 public struct EmailResponse: Sendable, Codable, Hashable {
   public var result: Result?
   public var success: Bool
   public var errors: [MessageContent]
   public var messages: [MessageContent]
 
+  @MemberwiseInit(.public)
   public struct Result: Sendable, Codable, Hashable {
     public var delivered: [String]
     public var permanentBounces: [String]

--- a/Sources/Images/Client.swift
+++ b/Sources/Images/Client.swift
@@ -1,22 +1,14 @@
 import Foundation
 import HTTPClient
 import HTTPTypes
+import MemberwiseInit
 
+@MemberwiseInit(.public)
 public struct Client<HTTPClient: HTTPClientProtocol & Sendable>: Sendable {
   public var accountId: String
   public var apiToken: String
   public var httpClient: HTTPClient
-  public var baseURL = URL(string: "https://api.cloudflare.com/client/v4")!
-
-  public init(
-    accountId: String,
-    apiToken: String,
-    httpClient: HTTPClient
-  ) {
-    self.apiToken = apiToken
-    self.accountId = accountId
-    self.httpClient = httpClient
-  }
+  public var baseURL: URL = URL(string: "https://api.cloudflare.com/client/v4")!
 
   func execute(_ request: HTTPRequest, body: Data? = nil) async throws -> (Data, HTTPResponse) {
     var request = request


### PR DESCRIPTION
## Summary

- Add MemberwiseInit dependency.
- Replace simple public memberwise initializers with `@MemberwiseInit(.public)`.
- Add public memberwise initialization for `EmailResponse` and `EmailResponse.Result`.

## Notes

- Custom initializers that convert values or implement decoding behavior are unchanged.
- `Client.baseURL` now has an explicit `URL` type annotation because MemberwiseInit requires typed stored properties with default values.

Closes #51

## Validation

- `swift package resolve`
- `swift test --filter MemberwiseInit`

Full `swift test` builds successfully, then existing live API tests fail locally because `ACCOUNT_ID` and API token environment variables are not set.
